### PR TITLE
fix: uses context to prevent infinite loop in populateArchiveBlock

### DIFF
--- a/src/payload/hooks/populateArchiveBlock.ts
+++ b/src/payload/hooks/populateArchiveBlock.ts
@@ -2,7 +2,7 @@ import type { AfterReadHook } from 'payload/dist/collections/config/types'
 
 import type { Page, Product } from '../payload-types'
 
-export const populateArchiveBlock: AfterReadHook = async ({ doc, req: { payload } }) => {
+export const populateArchiveBlock: AfterReadHook = async ({ doc, context, req: { payload } }) => {
   // pre-populate the archive block if `populateBy` is `collection`
   // then hydrate it on your front-end
 
@@ -16,22 +16,25 @@ export const populateArchiveBlock: AfterReadHook = async ({ doc, req: { payload 
           }>
         }
 
-        if (archiveBlock.populateBy === 'collection') {
+        if (archiveBlock.populateBy === 'collection' && !context.isPopulatingArchiveBlock) {
           const res: { totalDocs: number; docs: Product[] } = await payload.find({
             collection: archiveBlock?.relationTo || 'products',
             limit: archiveBlock.limit || 10,
+            context: {
+              isPopulatingArchiveBlock: true,
+            },
             where: {
               ...((archiveBlock?.categories?.length || 0) > 0
                 ? {
-                    categories: {
-                      in: archiveBlock?.categories
-                        ?.map(cat => {
-                          if (typeof cat === 'string') return cat
-                          return cat.id
-                        })
-                        .join(','),
-                    },
-                  }
+                  categories: {
+                    in: archiveBlock?.categories
+                      ?.map(cat => {
+                        if (typeof cat === 'string') return cat
+                        return cat.id
+                      })
+                      .join(','),
+                  },
+                }
                 : {}),
             },
             sort: '-publishedOn',


### PR DESCRIPTION
It was possible to enter into an infinite loop in certain scenarios where products may relate to other products via an archive, and if this happened, any operations that return `Product`s within Payload would enter into an infinite loop.

This was not a problem with Payload, but instead a problem with the implementation in our ecommerce boilerplate.

I've fixed the issue by using [Hooks Context](https://payloadcms.com/docs/hooks/context#preventing-infinite-loops).

We will update our Ecommerce boilerplate separately, accordingly.