### PR TITLE
Remove duplicate cart rendering in the NavBar for a logged in User.

### DIFF
--- a/src/app/_components/Header/Nav/index.tsx
+++ b/src/app/_components/Header/Nav/index.tsx
@@ -20,7 +20,6 @@ export const HeaderNav: React.FC<{ header: HeaderType }> = ({ header }) => {
       {navItems.map(({ link }, i) => {
         return <CMSLink key={i} {...link} appearance="none" />
       })}
-      <CartLink />
       {user && <Link href="/account">Account</Link>}
       {!user && (
         <Button


### PR DESCRIPTION
Cart is already rendered conditionally for a logged in User at Ln 34. 
If the user is logged in, it causes duplicate rendering of `Cart` in the navBar.

This PR removes the duplicate rendering of the Cart.